### PR TITLE
Specify Encoding

### DIFF
--- a/src/Wexflow.Core.Service.Client/WexflowServiceClient.cs
+++ b/src/Wexflow.Core.Service.Client/WexflowServiceClient.cs
@@ -17,6 +17,7 @@ namespace Wexflow.Core.Service.Client
         {
             string uri = Uri + "/workflows";
             var webClient = new WebClient();
+            webClient.Encoding = System.Text.Encoding.UTF8;
             var response = webClient.DownloadString(uri);
             var workflows = JsonConvert.DeserializeObject<WorkflowInfo[]>(response);
             return workflows;


### PR DESCRIPTION
The WebClient class uses System.Text.Encoding.Default if no other encoding is specified. All workflows and tasks are xml with assumed UTF-8 encoding, so using UTF-8 as encoding for the webclient should be fine.

This also fixes display of umlauts and other languages in the Manager